### PR TITLE
Add Jest tests for connection utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,11 +26,12 @@
 		"react-dom": "^18.2.0",
 		"react-scripts": "5.0.1"
 	},
-	"devDependencies": {
-		"autoprefixer": "^10.4.14",
-		"postcss": "^8.4.24",
-		"tailwindcss": "^3.3.0"
-	},
+        "devDependencies": {
+                "autoprefixer": "^10.4.14",
+                "postcss": "^8.4.24",
+                "tailwindcss": "^3.3.0",
+                "jest": "^29.7.0"
+        },
 	"browserslist": {
 		"production": [
 			">0.2%",

--- a/src/utils/__tests__/connectionPaths.test.js
+++ b/src/utils/__tests__/connectionPaths.test.js
@@ -1,0 +1,49 @@
+import { getConnectionPoint, calculateConnectionPath } from '../connectionPaths';
+import { getClassSize } from '../classSize';
+
+jest.mock('../classSize', () => ({
+  getClassSize: jest.fn(),
+}));
+
+const mockSize = { width: 100, height: 50 };
+const camera = { zoom: 1, offsetX: 0, offsetY: 0 };
+
+describe('getConnectionPoint', () => {
+  beforeEach(() => {
+    getClassSize.mockReturnValue(mockSize);
+  });
+
+  test('returns right center when target is to the right', () => {
+    const from = { position: { x: 0, y: 0 } };
+    const to = { position: { x: 200, y: 0 } };
+    const point = getConnectionPoint(from, to, camera);
+    expect(point).toEqual({ x: 100, y: 25 });
+  });
+
+  test('returns bottom center when target is below', () => {
+    const from = { position: { x: 0, y: 0 } };
+    const to = { position: { x: 0, y: 200 } };
+    const point = getConnectionPoint(from, to, camera);
+    expect(point).toEqual({ x: 50, y: 50 });
+  });
+});
+
+describe('calculateConnectionPath', () => {
+  beforeEach(() => {
+    getClassSize.mockReturnValue(mockSize);
+  });
+
+  test('creates bezier path for horizontal connection', () => {
+    const from = { position: { x: 0, y: 0 } };
+    const to = { position: { x: 200, y: 0 } };
+    const path = calculateConnectionPath(from, to, camera);
+    expect(path).toBe('M 100 25 C 150 25, 150 25, 200 25');
+  });
+
+  test('creates bezier path for vertical connection', () => {
+    const from = { position: { x: 0, y: 0 } };
+    const to = { position: { x: 0, y: 200 } };
+    const path = calculateConnectionPath(from, to, camera);
+    expect(path).toBe('M 50 50 C 50 100, 50 150, 50 200');
+  });
+});

--- a/src/utils/connectionPaths.js
+++ b/src/utils/connectionPaths.js
@@ -36,7 +36,7 @@ const calculateClassHeight = (classObj) => {
 };
 
 // Функция для вычисления точек подключения на краях класса
-const getConnectionPoint = (classObj, targetClassObj, localCamera) => {
+export const getConnectionPoint = (classObj, targetClassObj, localCamera) => {
 	// Получаем реальные размеры классов с учетом зума
 	const classSize = getClassSize(classObj, localCamera);
 	const targetSize = getClassSize(targetClassObj, localCamera);


### PR DESCRIPTION
## Summary
- export `getConnectionPoint`
- add Jest as devDependency
- test connection path helpers

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870d6506c98832080b13538d951ee06