### PR TITLE
Export getConnectionPoint helper

### DIFF
--- a/src/components/ConnectionsLayer.js
+++ b/src/components/ConnectionsLayer.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { calculateConnectionPath, calculatePreviewPath } from "../utils/connectionPaths";
+import { calculateConnectionPath, calculatePreviewPath, getConnectionPoint } from "../utils/connectionPaths";
 
 const ConnectionsLayer = ({ connections, connectionPreview, classes, localCamera, deleteConnection }) => {
 	// Функция для получения стиля линии в зависимости от типа связи
@@ -119,9 +119,9 @@ const ConnectionsLayer = ({ connections, connectionPreview, classes, localCamera
 					}
 				};
 
-				// Определяем, является ли связь прямой линией
-				const fromPoint = calculateConnectionPath.getConnectionPoint ? calculateConnectionPath.getConnectionPoint(fromClass, toClass, localCamera) : null;
-				const toPoint = calculateConnectionPath.getConnectionPoint ? calculateConnectionPath.getConnectionPoint(toClass, fromClass, localCamera) : null;
+                                // Определяем, является ли связь прямой линией
+                                const fromPoint = getConnectionPoint(fromClass, toClass, localCamera);
+                                const toPoint = getConnectionPoint(toClass, fromClass, localCamera);
 
 				let isStraightLine = false;
 				if (fromPoint && toPoint) {

--- a/src/utils/connectionPaths.js
+++ b/src/utils/connectionPaths.js
@@ -36,7 +36,7 @@ const calculateClassHeight = (classObj) => {
 };
 
 // Функция для вычисления точек подключения на краях класса
-const getConnectionPoint = (classObj, targetClassObj, localCamera) => {
+export const getConnectionPoint = (classObj, targetClassObj, localCamera) => {
 	// Получаем реальные размеры классов с учетом зума
 	const classSize = getClassSize(classObj, localCamera);
 	const targetSize = getClassSize(targetClassObj, localCamera);


### PR DESCRIPTION
## Summary
- expose `getConnectionPoint` from `connectionPaths`
- use `getConnectionPoint` directly in `ConnectionsLayer`

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870d64d701083209cd5443c65f6dc47