### PR TITLE
Fix typo in WorkspaceArea props comment

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -240,7 +240,7 @@ const AppContent = () => {
 					connectionPreview={connectionPreview}
 					selectedClass={selectedClass}
 					isConnecting={isConnecting}
-					connectionStart={connectionStart} // Добавляем недостающий проп
+					connectionStart={connectionStart} // Добавляем недостающий пропс
 					draggedClass={draggedClass}
 					localCamera={localCamera}
 					canvasRef={canvasRef}


### PR DESCRIPTION
## Summary
- correct typo in comment for `connectionStart` prop

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870d65d10508320abace09b2a1ea738